### PR TITLE
Change command verification

### DIFF
--- a/zsh-peco-history.zsh
+++ b/zsh-peco-history.zsh
@@ -8,8 +8,8 @@
 if which peco &> /dev/null; then
   function peco_select_history() {
     local tac
-    (which gtac &> /dev/null && tac="gtac") || \
-      (which tac &> /dev/null && tac="tac") || \
+    ((($+commands[gtac])) && tac="gtac") || \
+      (($+commands[tac])) && tac="tac" || \
       tac="tail -r"
     BUFFER=$(fc -l -n 1 | eval $tac | \
                peco --layout=bottom-up --query "$LBUFFER")


### PR DESCRIPTION
Hi,

I propose to changed command verification because `which` does sometimes produce an empty tac variable.
When this happens no history output is produces and an "Error: no buffer to work with was available" error is thrown.

Change tested in:
- zsh 4.3.1
- zsh 5.2

Code for verification taken from: [Re: Check existence of a program](http://www.zsh.org/mla/users/2011/msg00070.html)

Best Regards
Roang
