### PR TITLE
Fixes finding of gtac

### DIFF
--- a/zsh-peco-history.zsh
+++ b/zsh-peco-history.zsh
@@ -4,13 +4,12 @@
 #
 # Based on: https://github.com/mooz/percol#zsh-history-search
 # Get peco from: https://github.com/peco/peco
-#
+
 if which peco &> /dev/null; then
   function peco_select_history() {
     local tac
-    ((($+commands[gtac])) && tac="gtac") || \
-      (($+commands[tac])) && tac="tac" || \
-      tac="tail -r"
+    (($+commands[gtac])) && tac="gtac" || { (($+commands[tac])) && tac="tac" \
+        || { tac="tail -r" }}
     BUFFER=$(fc -l -n 1 | eval $tac | \
                peco --layout=bottom-up --query "$LBUFFER")
     CURSOR=$#BUFFER # move cursor


### PR DESCRIPTION
`gtac` installed on my system, but not `tac`:

```zsh
▶ type gtac
gtac is /usr/local/bin/gtac

▶ type tac
tac not found
```

Pre PR behaviour:

```zsh
▶ ((($+commands[gtac])) && tac="gtac") || (($+commands[tac])) && tac="tac"   || tac="tail -r" ; echo "Using: $tac"
Using: tac
```

Post PR:

```zsh
▶ (($+commands[gtac])) && tac="gtac" || { (($+commands[tac])) && tac="tac" \ || { tac="tail -r" }} ; echo "Using: $tac"
Using: gtac
```