### PR TITLE
 Remove duplicated commands in history

### DIFF
--- a/zsh-peco-history.zsh
+++ b/zsh-peco-history.zsh
@@ -8,6 +8,7 @@
 if which peco &> /dev/null; then
   function peco_select_history() {
     local tac
+    local uniq
     if (( $+commands[gtac] )); then
       tac="gtac"
     elif (( $+commands[tac] )); then
@@ -15,7 +16,14 @@ if which peco &> /dev/null; then
     else
       tac="tail -r"
     fi
-    BUFFER=$(fc -l -n 1 | eval $tac | \
+    if (( $+commands[perl] )); then
+      uniq="perl -ne 'print unless \$seen{\$_}++'"
+    elif (( $+commands[awk] )); then
+      uniq="awk '!seen[\$0]++'"
+    else
+      uniq="uniq"
+    fi
+    BUFFER=$(fc -l -n 1 | eval $tac | eval $uniq | \
                peco --layout=bottom-up --query "$LBUFFER")
     CURSOR=$#BUFFER # move cursor
     zle -R -c       # refresh

--- a/zsh-peco-history.zsh
+++ b/zsh-peco-history.zsh
@@ -8,9 +8,13 @@
 if which peco &> /dev/null; then
   function peco_select_history() {
     local tac
-    ((($+commands[gtac])) && tac="gtac") || \
-      (($+commands[tac])) && tac="tac" || \
+    if (( $+commands[gtac] )); then
+      tac="gtac"
+    elif (( $+commands[tac] )); then
+      tac="tac"
+    else
       tac="tail -r"
+    fi
     BUFFER=$(fc -l -n 1 | eval $tac | \
                peco --layout=bottom-up --query "$LBUFFER")
     CURSOR=$#BUFFER # move cursor


### PR DESCRIPTION
Previously, duplicated commands appeared in peco's history list.
If you had command history like
```
ls
ls -l
vim
ls
ls
```
then all commands were listed.
This commit suppresses all duplicated commands, so the history is listed
like this;
```
ls
ls -l
vim
```
If `perl` nor `awk` was not available, use `uniq` to remove duplicated lines.
In that case, only consecutive commands are removed from the list;
```
ls
ls -l
vim
ls
```