### PR TITLE
Allow customizing CLI arguments passed to peco

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ snippet from [percol](https://github.com/mooz/percol).
 
 ## Configuration Options
 
+### `ZSH_PECO_HISTORY_OPTS`
+
+Command-line arguments passed to `peco`. Defaults to `--layout=bottom-up` if the
+variable is not set.
+
+A lot of the Peco options available on the command-line, are also available via
+Peco's config file. It's up to you how you want to manage your Peco settings.
+
+For example, if you want to use the `bottom-up` layout, and change to fuzzy
+filtering:
+
+```bash
+ZSH_PECO_HISTORY_OPTS="--layout=bottom-up --initial-filter=Fuzzy"
+```
+
 ### `ZSH_PECO_HISTORY_DEDUP`
 
 De-duplicates all history entries before they are handed over to peco. Disabled

--- a/zsh-peco-history.zsh
+++ b/zsh-peco-history.zsh
@@ -34,7 +34,7 @@ if (( $+commands[peco] )); then
     fi
 
     BUFFER=$(fc -l -n 1 | eval $parse_cmd | \
-               peco --layout=bottom-up --query "$LBUFFER")
+               peco $ZSH_PECO_HISTORY_OPTS --query "$LBUFFER")
 
     CURSOR=$#BUFFER # move cursor
     zle -R -c       # refresh

--- a/zsh-peco-history.zsh
+++ b/zsh-peco-history.zsh
@@ -12,6 +12,10 @@
 # Based on: https://github.com/mooz/percol#zsh-history-search
 
 if (( $+commands[peco] )); then
+  if ! (( ${+ZSH_PECO_HISTORY_OPTS} )); then
+    ZSH_PECO_HISTORY_OPTS="--layout=bottom-up"
+  fi
+
   function peco_select_history() {
     local parse_cmd
 
@@ -34,7 +38,7 @@ if (( $+commands[peco] )); then
     fi
 
     BUFFER=$(fc -l -n 1 | eval $parse_cmd | \
-               peco $ZSH_PECO_HISTORY_OPTS --query "$LBUFFER")
+               peco ${=ZSH_PECO_HISTORY_OPTS} --query "$LBUFFER")
 
     CURSOR=$#BUFFER # move cursor
     zle -R -c       # refresh


### PR DESCRIPTION
_Note: This is a updated version of PR #2, as it has conflicts I was forced to rebase it on top of master._

Provides a new `ZSH_PECO_HISTORY_OPTS` environment variable to customize CLI arguments passed to `peco. Defaults to `--layout=bottom-up` ensuring default behavior does not change.